### PR TITLE
Fix failing tests with later versions of AssetPack (close #1 and #2)

### DIFF
--- a/t/01-include.t
+++ b/t/01-include.t
@@ -11,13 +11,12 @@ my $t = Test::Mojo->new($app);
 $app->plugin('Angular::MaterialDesign');
 $app->routes->get( '/test1' => 'test1' );
 $t->get_ok('/test1')->status_is(200)
-    ->text_like( 'script', qr{Angular Material Design},
-    'angular-material.js' )
+    ->text_like( 'script', qr{Angular Material Design}, 'angular-material.js' )
     ->text_like( 'style', qr{md-bottom-sheet\.md-grid}, 'css' );
 
 done_testing;
 
 __DATA__
 @@ test1.html.ep
-%= asset 'materialdesign.css' => {inline=> 1};
-%= asset 'materialdesign.js' => {inline=> 1};
+%= stylesheet sub { asset->processed('materialdesign.css')->map('content')->join };
+%= javascript sub { asset->processed('materialdesign.js' )->map('content')->join };


### PR DESCRIPTION
As reported in #1 and #2, recent versions of the AssetPack plugin
would cause this plugin to fail with the message:

> # Loading DEPRECATED Mojolicious::Plugin::AssetPack::Backcompat.
> Can't use string ("/css/angular-material.min.css") as an ARRAY ref

This patch fixes this by making some minor changes to the test suite
and the module itself:

* Assets are now loaded using the ->process method. The registration
  is no longer conditional, since the condition was always true.

* The AssetPack plugin is loaded with the Css and the JavaScript
  pipes when loading automatically. If the plugin is already loaded,
  the user configuration is respected.

* The include test no longer uses the `{ inline => 1 }` option, which
  seems to no longer work. Instead, it uses the example code present in
  the AssetPack documentation.